### PR TITLE
Read version from package.json directly

### DIFF
--- a/src/commands/version.js
+++ b/src/commands/version.js
@@ -1,12 +1,5 @@
-import fs from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { version } from "../../package.json" assert { type: "json" };
 
 export function runVersion() {
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = path.dirname(__filename);
-  const packagePath = path.join(__dirname, "../../package.json");
-
-  const data = JSON.parse(fs.readFileSync(packagePath, "utf8"));
-  console.log(`v${data.version}`);
+  console.log(`v${version}`);
 }


### PR DESCRIPTION
## Description

This pull request simplifies the implementation of the `runVersion` function in `src/commands/version.js` by directly importing the version from the `package.json` file, removing unnecessary file system and path operations.

Code simplification:

* Replaced manual reading and parsing of `package.json` using `fs` and `path` with a direct import of the `version` field, making the code cleaner and easier to maintain.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
