### PR TITLE
Update release workflow for CLI package publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,26 +7,37 @@ on:
 
 jobs:
   publish:
-    name: Publish Package
+    name: Publish CLI Package
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          registry-url: "https://registry.npmjs.org/"
+          registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
-        run: npm install
+        run: bun install --frozen-lockfile
 
-      - name: Build package
-        run: npm run build
+      - name: Build CLI package
+        run: bun run build --filter=packages/cli
+
+      - name: Verify npm package
+        run: npm pack --workspace=packages/cli
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --workspace=packages/cli --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request updates the release workflow for publishing the CLI package, switching the build and install process from npm to Bun, and improving the workflow's clarity and security. The most important changes are grouped below:

**Switch to Bun for Dependency Management and Build:**
* Replaced `npm install` with `bun install --frozen-lockfile` for installing dependencies, and replaced the generic build step with `bun run build --filter=packages/cli` to specifically build the CLI package.

**Workflow and Publishing Improvements:**
* Changed the publish step to use `npm publish --workspace=packages/cli --access public`, ensuring only the CLI package is published and that it is set as public.
* Added a verification step with `npm pack --workspace=packages/cli` to ensure the package is ready for publishing.

**Workflow Metadata and Permissions:**
* Updated the job name from "Publish Package" to "Publish CLI Package" for clarity.
* Added explicit `contents: read` permissions to the workflow for improved security.

Fixes: #27