### PR TITLE
fix: correct yarn global update command and improve global install detection

### DIFF
--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -99,10 +99,17 @@ function isGlobalInstall() {
   if (process.env.npm_config_global === "true") return true;
 
   const bin = process.argv[1] || "";
-  return (
-    /[/\\]node_modules[/\\].*[/\\].bin[/\\]/i.test(bin) ||
-    /[/\\]lib[/\\]node_modules[/\\]/i.test(bin)
-  );
+  const globalPatterns = [
+    /[/\\]node_modules[/\\].*[/\\]\.bin[/\\]/i, // npm/pnpm local bin shims
+    /[/\\]lib[/\\]node_modules[/\\]/i, // npm global (unix)
+    /[/\\]npm[/\\]node_modules[/\\]/i, // npm global (Windows AppData\Roaming\npm)
+    /[/\\]\.bun[/\\]bin[/\\]/i, // bun global
+    /[/\\]\.yarn[/\\]bin[/\\]/i, // yarn global (unix)
+    /[/\\]Yarn[/\\]Data[/\\]global[/\\]/i, // yarn global (Windows)
+    /[/\\]\.local[/\\]share[/\\]pnpm[/\\]/i, // pnpm global (unix)
+  ];
+
+  return globalPatterns.some((pattern) => pattern.test(bin));
 }
 
 function buildUpdateCommand(pkg: string): [string, string[]] {
@@ -117,7 +124,7 @@ function buildUpdateCommand(pkg: string): [string, string[]] {
 
     case "yarn":
       return global
-        ? ["npm", ["i", "-g", pkg]]
+        ? ["yarn", ["global", "add", pkg]]
         : ["yarn", ["add", `${pkg}@latest`]];
 
     case "bun":

--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -100,7 +100,6 @@ function isGlobalInstall() {
 
   const bin = process.argv[1] || "";
   const globalPatterns = [
-    /[/\\]node_modules[/\\].*[/\\]\.bin[/\\]/i, // npm/pnpm local bin shims
     /[/\\]lib[/\\]node_modules[/\\]/i, // npm global (unix)
     /[/\\]npm[/\\]node_modules[/\\]/i, // npm global (Windows AppData\Roaming\npm)
     /[/\\]\.bun[/\\]bin[/\\]/i, // bun global


### PR DESCRIPTION
## Description
Fixed the auto-update mechanism in the `thyra` CLI to correctly handle updates across different package managers and installation contexts.

Two issues were addressed in `src/commands/version.ts`:

1. **`buildUpdateCommand()`** — When yarn was detected for a global install, the function incorrectly fell back to `npm i -g <pkg>` instead of using yarn's own global install command. This has been fixed to use `yarn global add <pkg>`.

2. **`isGlobalInstall()`** — The global install detection only checked two path patterns (`node_modules/.bin/` and `lib/node_modules/`), which missed several real-world global install locations such as Bun's global bin folder, Yarn's global bin folder (both Unix and Windows), pnpm's global store, and Windows npm global installs (`AppData\Roaming\npm`). Added additional patterns to cover these cases so global installs are detected reliably across package managers and operating systems.

## Related Issue
Closes #24

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works