### PR TITLE
Bump version to 1.3.1 and update workspace paths

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thyra-docs",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig([
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    files: ["packages/**/*.ts"],
+    files: ["tools/**/*.ts"],
     languageOptions: {
       ecmaVersion: 2022,
       globals: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thyra/monorepo",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "description": "Monorepo for the Thyra CLI and documentation site.",
   "license": "MIT",

--- a/scripts/version-bump.ts
+++ b/scripts/version-bump.ts
@@ -28,8 +28,8 @@ root.version = newVersion;
 
 fs.writeFileSync(rootPath, JSON.stringify(root, null, 2) + "\n");
 
-// bump all workspace packages
-const folders = ["apps", "packages"];
+// bump all workspaces
+const folders = ["apps", "tools"];
 
 for (const folder of folders) {
   if (!fs.existsSync(folder)) continue;

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thyra",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Simple project folder opener CLI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
This pull request updates the project version across multiple packages and makes adjustments to the workspace structure and linting configuration. The key changes are grouped below:

**Version Bump:**

* Bumped the version from `1.3.0` to `1.3.1` in `package.json`, `apps/web/package.json`, and `tools/cli/package.json` to reflect a new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L4-R4) [[3]](diffhunk://#diff-054af018b6019be0cece3720a8870990dd25a740dcb845dda80057caf07bdbf0L3-R3)

**Workspace and Tooling Adjustments:**

* Updated the version bump script (`scripts/version-bump.ts`) to include the `tools` directory instead of `packages`, ensuring all relevant workspaces are updated.
* Changed the ESLint configuration (`eslint.config.mjs`) to lint TypeScript files in the `tools` directory instead of `packages`, aligning linting with the new workspace structure.