### PR TITLE
Fix release workflow to build and publish correct CLI package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,14 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build CLI package
-        run: bun run build --filter=tools/cli
+        run: bun run build --filter=thyra
 
       - name: Verify npm package
-        run: npm pack --workspace=tools/cli
+        working-directory: ./tools/cli
+        run: npm pack
 
       - name: Publish to npm
-        run: npm publish --workspace=tools/cli --access public
+        working-directory: ./tools/cli
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request updates the release workflow for publishing the CLI package. The main changes involve adjusting the build and publish steps to ensure commands are run in the correct directory and using the appropriate filters.

Workflow improvements:

* Changed the build command to use `--filter=thyra` instead of `--filter=tools/cli` for building the CLI package.
* Updated the `npm pack` and `npm publish` steps to run in the `tools/cli` directory by setting `working-directory: ./tools/cli`, and removed the use of the `--workspace` flag.

Fixes: #51 