### PR TITLE
Implement release note checks and update README generation workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build CLI package
         run: bun run build --filter=thyra
 
+      - name: Copy true README content to package folder
+        run: cp apps/web/docs/thyra/latest-release.md tools/cli/README.md
+
       - name: Verify npm package
         working-directory: ./tools/cli
         run: npm pack

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,6 +4,7 @@ set -e
 
 echo "Running pre-commit checks..."
 
+bun run scripts/check-latest-release.ts
 bun run lint
 bun run typecheck
 bun run build

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean",
     "prepare": "husky",
+    "check:latest-release": "bun run scripts/check-latest-release.ts",
     "bump:patch": "bun run scripts/version-bump.ts patch",
     "bump:minor": "bun run scripts/version-bump.ts minor",
     "bump:major": "bun run scripts/version-bump.ts major"

--- a/scripts/check-latest-release.ts
+++ b/scripts/check-latest-release.ts
@@ -1,0 +1,11 @@
+import fs from "fs";
+
+const latestReleasePath = "./apps/web/docs/thyra/latest-release.md";
+const content = fs.readFileSync(latestReleasePath, "utf-8");
+
+if (content.trim().length === 0) {
+  console.error(
+    "Commit blocked: apps/web/docs/thyra/latest-release.md is empty. Add release notes before committing.",
+  );
+  process.exit(1);
+}

--- a/scripts/version-bump.ts
+++ b/scripts/version-bump.ts
@@ -28,6 +28,14 @@ root.version = newVersion;
 
 fs.writeFileSync(rootPath, JSON.stringify(root, null, 2) + "\n");
 
+if (type !== "patch") {
+  const latestReleasePath = "./apps/web/docs/thyra/latest-release.md";
+  const versionReleasePath = `./apps/web/docs/thyra/v${newVersion}.md`;
+
+  fs.writeFileSync(versionReleasePath, "");
+  fs.writeFileSync(latestReleasePath, "");
+}
+
 // bump all workspaces
 const folders = ["apps", "tools"];
 


### PR DESCRIPTION
This pull request introduces improvements to the release workflow for the CLI package, focusing on ensuring that release notes are properly managed and not empty, and automating the handling of release documentation. The main changes add pre-commit and release-time checks for release notes, automate copying the latest release notes to the CLI package, and update the release note files during version bumps.

**Release note management and validation:**

* Added a new script `scripts/check-latest-release.ts` that blocks commits if `apps/web/docs/thyra/latest-release.md` is empty, ensuring that release notes are present before any commit.
* Updated `.husky/pre-commit` to run the new release note check as part of pre-commit hooks.
* Added an npm script `check:latest-release` to run the release note check script.

**Release workflow automation:**

* Modified `.github/workflows/release.yml` to copy the latest release notes (`latest-release.md`) into the CLI package's `README.md` before publishing, ensuring the package README is always up to date with the latest release notes.
* Updated `scripts/version-bump.ts` to clear the contents of `latest-release.md` and create a new versioned release note file whenever a minor or major version bump occurs, preparing for the next release notes to be written.

Fixes: #54 