### PR TITLE
Enhance 'open' command for custom editor support and update help

### DIFF
--- a/tools/cli/src/commands/help.ts
+++ b/tools/cli/src/commands/help.ts
@@ -19,8 +19,8 @@ export function runHelp(exitCode: number) {
       Description: "Scan and register projects from a directory",
     },
     {
-      Command: colorize("thyra open <name>"),
-      Description: "Open folder in your editor",
+      Command: colorize("thyra open <name> | <editor>"),
+      Description: "Open folder in your editor (default: code) (<editor> is overridden by $EDITOR env variable)",
     },
     {
       Command: colorize("thyra update <name> <folder_path>"),

--- a/tools/cli/src/commands/help.ts
+++ b/tools/cli/src/commands/help.ts
@@ -5,8 +5,8 @@ import { colorize, printCommandTable } from "~/core";
 export function runHelp(exitCode: number) {
   console.log(
     `\n${color.bold(color.cyan("thyra"))} ${color.dim(
-      "- Quick shortcut manager for project folders"
-    )}\n`
+      "- Quick shortcut manager for project folders",
+    )}\n`,
   );
 
   const rows = [
@@ -19,8 +19,9 @@ export function runHelp(exitCode: number) {
       Description: "Scan and register projects from a directory",
     },
     {
-      Command: colorize("thyra open <name> | <editor>"),
-      Description: "Open folder in your editor (default: code) (<editor> is overridden by $EDITOR env variable)",
+      Command: colorize("thyra open <name> | --editor <editor>"),
+      Description:
+        "Open folder in your editor (default: $EDITOR or 'code') [--editor to override]",
     },
     {
       Command: colorize("thyra update <name> <folder_path>"),
@@ -28,7 +29,8 @@ export function runHelp(exitCode: number) {
     },
     {
       Command: colorize("thyra remove <name> | --all | --force"),
-      Description: "Remove a saved path or all paths (--force to skip confirmation)",
+      Description:
+        "Remove a saved path or all paths (--force to skip confirmation)",
     },
     { Command: colorize("thyra list"), Description: "Show all saved paths" },
     { Command: colorize("thyra --version"), Description: "Show CLI version" },
@@ -40,30 +42,28 @@ export function runHelp(exitCode: number) {
   console.log(
     `\n${color.bold(color.underline("Examples:"))}
   ${colorize("thyra config <name> <folder_path>")}   ${color.dim(
-      "# Save a path"
-    )}
+    "# Save a path",
+  )}
   ${colorize("thyra import ./projects")}             ${color.dim(
-      "# Import multiple projects"
-    )}
+    "# Import multiple projects",
+  )}
   ${colorize("thyra open <name>")}                   ${color.dim(
-      "# Open in editor"
-    )}
+    "# Open in editor",
+  )}
   ${colorize("thyra update <name> <folder_path>")} ${color.dim(
-      "# Update an existing saved path"
-    )}
+    "# Update an existing saved path",
+  )}
   ${colorize("thyra remove <name>")}                ${color.dim(
-      "# Remove a saved path"
-    )}
+    "# Remove a saved path",
+  )}
   ${colorize("thyra remove --all")}                 ${color.dim(
-      "# Remove all saved paths"
-    )}
+    "# Remove all saved paths",
+  )}
   ${colorize("thyra --version")}
 
 ${color.bold(color.underline("Environment:"))}
-  ${color.cyan("EDITOR")}  ${color.dim(
-      'Editor command (default: "code")'
-    )}
-`
+  ${color.cyan("EDITOR")}  ${color.dim('Editor command (default: "code")')}
+`,
   );
 
   if (typeof exitCode === "number") process.exit(exitCode);

--- a/tools/cli/src/commands/help.ts
+++ b/tools/cli/src/commands/help.ts
@@ -19,9 +19,9 @@ export function runHelp(exitCode: number) {
       Description: "Scan and register projects from a directory",
     },
     {
-      Command: colorize("thyra open <name> | --editor <editor>"),
+      Command: colorize("thyra open <name> [-e | --editor <editor>]"),
       Description:
-        "Open folder in your editor (default: $EDITOR or 'code') [--editor to override]",
+        "Open folder in your editor (default: $EDITOR or 'code')",
     },
     {
       Command: colorize("thyra update <name> <folder_path>"),
@@ -49,6 +49,9 @@ export function runHelp(exitCode: number) {
   )}
   ${colorize("thyra open <name>")}                   ${color.dim(
     "# Open in editor",
+  )}
+  ${colorize("thyra open <name> -e <editor>")}       ${color.dim(
+    "# Open in <editor>",
   )}
   ${colorize("thyra update <name> <folder_path>")} ${color.dim(
     "# Update an existing saved path",

--- a/tools/cli/src/commands/open.ts
+++ b/tools/cli/src/commands/open.ts
@@ -10,7 +10,7 @@ function quoteShellArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function openInEditor(folderPath: string, editor? : string): void {
+function openInEditor(folderPath: string, editor?: string): void {
   const editorCmd = editor || "code";
   const command = `${editorCmd} ${quoteShellArg(folderPath)}`;
 
@@ -23,7 +23,9 @@ function openInEditor(folderPath: string, editor? : string): void {
 
   child.on("error", (error) => {
     if (editorCmd !== "explorer") {
-      console.error(`Failed to start editor "${editorCmd}". Is it installed and on your PATH?`);
+      console.error(
+        `Failed to start editor "${editorCmd}". Is it installed and on your PATH?`,
+      );
       console.error(error.message);
       process.exit(1);
     }
@@ -38,7 +40,9 @@ function openInEditor(folderPath: string, editor? : string): void {
 }
 
 function levenshteinDistance(a: string, b: string): number {
-  const matrix = Array.from({ length: a.length + 1 }, () => Array(b.length + 1).fill(0));
+  const matrix = Array.from({ length: a.length + 1 }, () =>
+    Array(b.length + 1).fill(0),
+  );
   for (let i = 0; i <= a.length; i++) matrix[i][0] = i;
   for (let j = 0; j <= b.length; j++) matrix[0][j] = j;
 
@@ -48,7 +52,7 @@ function levenshteinDistance(a: string, b: string): number {
       matrix[i][j] = Math.min(
         matrix[i - 1][j] + 1,
         matrix[i][j - 1] + 1,
-        matrix[i - 1][j - 1] + cost
+        matrix[i - 1][j - 1] + cost,
       );
     }
   }
@@ -57,7 +61,24 @@ function levenshteinDistance(a: string, b: string): number {
 
 export function runOpen(store: ConfigStore, args: string[]): void {
   const name = args[0];
-  const editor = args[1] || process.env.EDITOR;
+
+  let editor: string | undefined = process.env.EDITOR;
+  if (args[1]) {
+    if (args[1] === "--editor" || args[1] === "-e") {
+      if (args[2]) {
+        editor = args[2];
+      } else {
+        console.error("Missing <editor> argument for 'open' command.");
+        console.log("Usage: thyra open <name> --editor <editor>");
+        process.exit(1);
+      }
+    } else {
+      console.error(`Unknown option "${args[1]}" for 'open' command.`);
+      console.log("Usage: thyra open <name> [--editor <editor>]");
+      process.exit(1);
+    }
+  }
+
   if (!name) {
     console.error("Missing <name> argument for 'open' command.");
     console.log("Usage: thyra open <name>");
@@ -66,9 +87,9 @@ export function runOpen(store: ConfigStore, args: string[]): void {
 
   if (!store.has(name)) {
     console.error(
-      `No folder found for alias "${name}". Use 'thyra list' to see saved entries.`
+      `No folder found for alias "${name}". Use 'thyra list' to see saved entries.`,
     );
-    
+
     // Fuzzy matching suggestion
     const allAliases = Object.keys(store.all());
     if (allAliases.length > 0) {
@@ -85,12 +106,12 @@ export function runOpen(store: ConfigStore, args: string[]): void {
           closest = alias;
         }
       }
-      
+
       if (closest && (closest.includes(name) || minDistance <= 3)) {
         console.log(`\nDid you mean: ${color.green(closest)} ?`);
       }
     }
-    
+
     process.exit(1);
   }
 

--- a/tools/cli/src/commands/open.ts
+++ b/tools/cli/src/commands/open.ts
@@ -10,8 +10,8 @@ function quoteShellArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function openInEditor(folderPath: string) {
-  const editorCmd = process.env.EDITOR || "code";
+function openInEditor(folderPath: string, editor? : string): void {
+  const editorCmd = editor || "code";
   const command = `${editorCmd} ${quoteShellArg(folderPath)}`;
 
   console.log(`Opening "${folderPath}" in "${editorCmd}"...`);
@@ -57,6 +57,7 @@ function levenshteinDistance(a: string, b: string): number {
 
 export function runOpen(store: ConfigStore, args: string[]): void {
   const name = args[0];
+  const editor = args[1] || process.env.EDITOR;
   if (!name) {
     console.error("Missing <name> argument for 'open' command.");
     console.log("Usage: thyra open <name>");
@@ -100,5 +101,5 @@ export function runOpen(store: ConfigStore, args: string[]): void {
   }
 
   ensureDirectoryExists(entry.path);
-  openInEditor(entry.path);
+  openInEditor(entry.path, editor);
 }

--- a/tools/cli/src/commands/remove.ts
+++ b/tools/cli/src/commands/remove.ts
@@ -4,7 +4,10 @@ import color from "picocolors";
 
 import type { ConfigStore } from "~/core";
 
-export async function runRemove(store: ConfigStore, args: string[]): Promise<void> {
+export async function runRemove(
+  store: ConfigStore,
+  args: string[],
+): Promise<void> {
   const isAll = args.includes("--all");
   const isForce = args.includes("--force");
 
@@ -16,9 +19,9 @@ export async function runRemove(store: ConfigStore, args: string[]): Promise<voi
     }
 
     if (!isForce) {
-      console.log(color.yellow("⚠️  You are about to delete ALL projects."));
+      console.log(color.yellow("⚠️ You are about to delete ALL projects."));
       console.log(color.yellow("This action cannot be undone."));
-      
+
       const rl = readline.createInterface({
         input: process.stdin,
         output: process.stdout,
@@ -55,7 +58,7 @@ export async function runRemove(store: ConfigStore, args: string[]): Promise<voi
 
   if (!store.has(name)) {
     console.error(
-      `No folder found for alias "${name}". Use 'thyra list' to see saved entries.`
+      `No folder found for alias "${name}". Use 'thyra list' to see saved entries.`,
     );
     process.exit(1);
   }


### PR DESCRIPTION
This pull request updates the `thyra open` CLI command to allow users to specify a preferred editor directly as a command argument, while also clarifying the help text and improving how the editor is determined. The command now defaults to `code` (VS Code) unless an editor is provided as an argument or via the `$EDITOR` environment variable.

**Command behavior improvements:**

* The `thyra open` command now accepts an optional `<editor>` argument, allowing users to specify which editor to use when opening a project. If not provided, it falls back to the `$EDITOR` environment variable, and finally defaults to `code`. [[1]](diffhunk://#diff-6614f0f0a2f780032fff367e0d7ce8712ac1ab81ce8641be3951b5e1fca4703dR60) [[2]](diffhunk://#diff-6614f0f0a2f780032fff367e0d7ce8712ac1ab81ce8641be3951b5e1fca4703dL13-R14) [[3]](diffhunk://#diff-6614f0f0a2f780032fff367e0d7ce8712ac1ab81ce8641be3951b5e1fca4703dL103-R104)

**Documentation updates:**

* The help text for the `thyra open` command is updated to reflect the new usage, specifying the default editor and the precedence of the `$EDITOR` environment variable.

Fixes: #30 