### PR TITLE
feat: add 'cd' command to change directory

### DIFF
--- a/tools/cli/src/cli.ts
+++ b/tools/cli/src/cli.ts
@@ -2,6 +2,7 @@ import {
   runConfig,
   runVersion,
   runOpen,
+  runCd,
   runList,
   runHelp,
   runRemove,
@@ -35,6 +36,9 @@ import { getConfigFilePath, ConfigStore } from "~/core";
       break;
     case "open":
       runOpen(store, rest);
+      break;
+    case "cd":
+      runCd(store, rest);
       break;
     case "remove":
       runRemove(store, rest);

--- a/tools/cli/src/commands/cd.ts
+++ b/tools/cli/src/commands/cd.ts
@@ -1,0 +1,38 @@
+import color from "picocolors";
+
+import { ConfigStore } from "~/core";
+import { ensureDirectoryExists, suggestClosestAlias } from "~/utils";
+
+export function runCd(store: ConfigStore, args: string[]): void {
+  const name = args[0];
+
+  if (!name) {
+    console.error("Missing <name> argument for 'cd' command.");
+    console.error("Usage: thyra cd <name>");
+    process.exit(1);
+  }
+
+  if (!store.has(name)) {
+    console.error(
+      `No folder found for alias "${name}". Use 'thyra list' to see saved entries.`
+    );
+
+    const allAliases = Object.keys(store.all());
+    const closest = suggestClosestAlias(name, allAliases);
+    if (closest) {
+      console.error(`\nDid you mean: ${color.green(closest)} ?`);
+    }
+
+    process.exit(1);
+  }
+
+  const entry = store.get(name);
+  if (!entry || !entry.path) {
+    console.error(`Invalid folder path for alias "${name}".`);
+    process.exit(1);
+  }
+
+  ensureDirectoryExists(entry.path);
+
+  process.stdout.write(`${entry.path}\n`);
+}

--- a/tools/cli/src/commands/cd.ts
+++ b/tools/cli/src/commands/cd.ts
@@ -1,7 +1,7 @@
 import color from "picocolors";
 
 import { ConfigStore } from "~/core";
-import { ensureDirectoryExists, suggestClosestAlias } from "~/utils";
+import { ensureDirectoryExists, resolveFolderPath, suggestClosestAlias } from "~/utils";
 
 export function runCd(store: ConfigStore, args: string[]): void {
   const name = args[0];
@@ -32,7 +32,8 @@ export function runCd(store: ConfigStore, args: string[]): void {
     process.exit(1);
   }
 
-  ensureDirectoryExists(entry.path);
+  const resolvedPath = resolveFolderPath(entry.path);
+  ensureDirectoryExists(resolvedPath);
 
-  process.stdout.write(`${entry.path}\n`);
+  process.stdout.write(`${resolvedPath}\n`);
 }

--- a/tools/cli/src/commands/help.ts
+++ b/tools/cli/src/commands/help.ts
@@ -23,6 +23,10 @@ export function runHelp(exitCode: number) {
       Description: "Open folder in your editor",
     },
     {
+      Command: colorize("thyra cd <name>"),
+      Description: "Change directory to a saved path",
+    },
+    {
       Command: colorize("thyra update <name> <folder_path>"),
       Description: "Update an existing saved path",
     },
@@ -50,6 +54,9 @@ export function runHelp(exitCode: number) {
     )}
   ${colorize("thyra update <name> <folder_path>")} ${color.dim(
       "# Update an existing saved path"
+    )}
+  ${colorize("thyra cd <name>")}                     ${color.dim(
+      "# Print a saved folder's path"
     )}
   ${colorize("thyra remove <name>")}                ${color.dim(
       "# Remove a saved path"

--- a/tools/cli/src/commands/help.ts
+++ b/tools/cli/src/commands/help.ts
@@ -24,7 +24,7 @@ export function runHelp(exitCode: number) {
     },
     {
       Command: colorize("thyra cd <name>"),
-      Description: "Change directory to a saved path",
+      Description: "Print a saved folder's path",
     },
     {
       Command: colorize("thyra update <name> <folder_path>"),

--- a/tools/cli/src/commands/index.ts
+++ b/tools/cli/src/commands/index.ts
@@ -2,6 +2,7 @@ export { runConfig } from "./config";
 export { runVersion } from "./version";
 export { runOpen } from "./open";
 export { runList } from "./list";
+export { runCd } from "./cd";
 export { runHelp } from "./help";
 export { runRemove } from "./remove";
 export { runUpdate } from "./update";

--- a/tools/cli/src/commands/open.ts
+++ b/tools/cli/src/commands/open.ts
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import color from "picocolors";
 
 import { ConfigStore } from "~/core";
-import { ensureDirectoryExists } from "~/utils";
+import { ensureDirectoryExists, suggestClosestAlias } from "~/utils";
 
 function quoteShellArg(value: string): string {
   if (process.platform === "win32") return `"${value.replace(/"/g, '""')}"`;
@@ -37,24 +37,6 @@ function openInEditor(folderPath: string) {
   });
 }
 
-function levenshteinDistance(a: string, b: string): number {
-  const matrix = Array.from({ length: a.length + 1 }, () => Array(b.length + 1).fill(0));
-  for (let i = 0; i <= a.length; i++) matrix[i][0] = i;
-  for (let j = 0; j <= b.length; j++) matrix[0][j] = j;
-
-  for (let i = 1; i <= a.length; i++) {
-    for (let j = 1; j <= b.length; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      matrix[i][j] = Math.min(
-        matrix[i - 1][j] + 1,
-        matrix[i][j - 1] + 1,
-        matrix[i - 1][j - 1] + cost
-      );
-    }
-  }
-  return matrix[a.length][b.length];
-}
-
 export function runOpen(store: ConfigStore, args: string[]): void {
   const name = args[0];
   if (!name) {
@@ -67,29 +49,13 @@ export function runOpen(store: ConfigStore, args: string[]): void {
     console.error(
       `No folder found for alias "${name}". Use 'thyra list' to see saved entries.`
     );
-    
-    // Fuzzy matching suggestion
+
     const allAliases = Object.keys(store.all());
-    if (allAliases.length > 0) {
-      let closest = "";
-      let minDistance = Infinity;
-      for (const alias of allAliases) {
-        if (alias.includes(name)) {
-          closest = alias;
-          break; // fast path
-        }
-        const dist = levenshteinDistance(name, alias);
-        if (dist < minDistance) {
-          minDistance = dist;
-          closest = alias;
-        }
-      }
-      
-      if (closest && (closest.includes(name) || minDistance <= 3)) {
-        console.log(`\nDid you mean: ${color.green(closest)} ?`);
-      }
+    const closest = suggestClosestAlias(name, allAliases);
+    if (closest) {
+      console.log(`\nDid you mean: ${color.green(closest)} ?`);
     }
-    
+
     process.exit(1);
   }
 

--- a/tools/cli/src/utils/index.ts
+++ b/tools/cli/src/utils/index.ts
@@ -1,1 +1,2 @@
 export {resolveFolderPath, ensureDirectoryExists} from "./path";
+export {suggestClosestAlias} from "./suggest-alias";

--- a/tools/cli/src/utils/suggest-alias.ts
+++ b/tools/cli/src/utils/suggest-alias.ts
@@ -1,0 +1,39 @@
+function levenshteinDistance(a: string, b: string): number {
+  const matrix = Array.from({ length: a.length + 1 }, () => Array(b.length + 1).fill(0));
+  for (let i = 0; i <= a.length; i++) matrix[i][0] = i;
+  for (let j = 0; j <= b.length; j++) matrix[0][j] = j;
+
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return matrix[a.length][b.length];
+}
+
+export function suggestClosestAlias(name: string, aliases: string[]): string | null {
+  let closest = "";
+  let minDistance = Infinity;
+
+  for (const alias of aliases) {
+    if (alias.includes(name)) {
+      return alias; // fast path
+    }
+    const dist = levenshteinDistance(name, alias);
+    if (dist < minDistance) {
+      minDistance = dist;
+      closest = alias;
+    }
+  }
+
+  if (closest && minDistance <= 3) {
+    return closest;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Description

Adds a new `thyra cd <name>` command that resolves a saved alias to its
folder path, for developers who want to jump straight into a project in
the terminal instead of opening it in an editor.

Since a CLI process can never change the working directory of the shell
that launched it, `thyra cd <name>` prints the resolved absolute path to
stdout (all messages/errors go to stderr, so the output is safe to use in
shell command substitution). Users can wire this into a shell function
(e.g. in `~/.zshrc`) to capture the printed path and `cd` into it
automatically, similar to how `z`/`zoxide`/`autojump` work.

Along the way, the fuzzy "Did you mean?" alias-matching logic that
previously lived only inside `open.ts` was extracted into a shared
`suggestClosestAlias()` utility in `utils/suggest-alias.ts`, so both
`open` and `cd` reuse the same matching behavior instead of duplicating
it. `open.ts`'s external behavior is unchanged.

**Changes:**
- New: `commands/cd.ts` — implements `runCd()`
- New: `utils/suggest-alias.ts` — shared fuzzy-match helper (extracted from `open.ts`)
- Updated: `commands/open.ts` — now uses the shared helper instead of its own inline copy
- Updated: `commands/index.ts`, `utils/index.ts` — export the new command/helper
- Updated: `cli.ts` — registers `cd` as a recognized subcommand
- Updated: `commands/help.ts` — documents `thyra cd <name>` in `--help`

## Related Issue

Closes #34 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works