### PR TITLE
Include LICENSE file in npm package and update README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,10 @@ jobs:
       - name: Build CLI package
         run: bun run build --filter=thyra
 
-      - name: Copy true README content to package folder
-        run: cp apps/web/docs/thyra/latest-release.md tools/cli/README.md
+      - name: Copy README and LICENSE to package folder
+        run: |
+          cp apps/web/docs/thyra/latest-release.md tools/cli/README.md
+          cp LICENSE tools/cli/LICENSE
 
       - name: Verify npm package
         working-directory: ./tools/cli

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "engines": {
     "bun": ">=1.3.0"


### PR DESCRIPTION
This pull request makes improvements to the packaging and distribution of the CLI tool by ensuring that both the `README.md` and `LICENSE` files are included in the npm package. The workflow and package configuration files have been updated to support this.

**Packaging improvements:**

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L37-R40): The release workflow now copies both the `README.md` and `LICENSE` files into the CLI package folder before publishing.
* [`tools/cli/package.json`](diffhunk://#diff-054af018b6019be0cece3720a8870990dd25a740dcb845dda80057caf07bdbf0L19-R20): The `LICENSE` file is now included in the `files` array, ensuring it is part of the published npm package.

Fixes: #58 