### PR TITLE
Add 'cd' command for directory change and update help documentation

### DIFF
--- a/tools/cli/src/cli.ts
+++ b/tools/cli/src/cli.ts
@@ -7,6 +7,7 @@ import {
   runRemove,
   runUpdate,
   runImport,
+  runCd,
 } from "./commands";
 import { getConfigFilePath, ConfigStore } from "~/core";
 
@@ -47,6 +48,9 @@ import { getConfigFilePath, ConfigStore } from "~/core";
       break;
     case "import":
       runImport(store, rest);
+      break;
+    case "cd":
+      runCd(store, rest);
       break;
     default:
       console.error(`Unknown command: ${command}`);

--- a/tools/cli/src/commands/cd.ts
+++ b/tools/cli/src/commands/cd.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 
 import { ConfigStore } from "~/core";
+import { ensureDirectoryExists } from "~/utils";
 
 export function runCd(store: ConfigStore, args: string[]): void {
   const name = args[0];
@@ -17,6 +18,8 @@ export function runCd(store: ConfigStore, args: string[]): void {
     console.error(`No project found with alias "${name}".`);
     process.exit(1);
   }
+
+  ensureDirectoryExists(entry.path);
 
   try {
     // Open a new Terminal window in the project directory

--- a/tools/cli/src/commands/cd.ts
+++ b/tools/cli/src/commands/cd.ts
@@ -1,0 +1,33 @@
+import { spawn } from "node:child_process";
+
+import { ConfigStore } from "~/core";
+
+export function runCd(store: ConfigStore, args: string[]): void {
+  const name = args[0];
+
+  if (!name) {
+    console.error("Missing argument for 'cd' command.");
+    console.log("Usage: thyra cd <alias>");
+    process.exit(1);
+  }
+
+  const entry = store.get(name);
+
+  if (!entry || !entry.path) {
+    console.error(`No project found with alias "${name}".`);
+    process.exit(1);
+  }
+
+  try {
+    // Open a new Terminal window in the project directory
+    spawn("open", ["-a", "Terminal", entry.path], {
+      detached: true,
+      stdio: "ignore",
+    });
+
+    console.log(`Opened terminal at: ${entry.path}`);
+  } catch (err) {
+    console.error(`Failed to open terminal at "${entry.path}":`, err);
+    process.exit(1);
+  }
+}

--- a/tools/cli/src/commands/help.ts
+++ b/tools/cli/src/commands/help.ts
@@ -20,9 +20,9 @@ export function runHelp(exitCode: number) {
     },
     {
       Command: colorize("thyra open <name> [-e | --editor <editor>]"),
-      Description:
-        "Open folder in your editor (default: $EDITOR or 'code')",
+      Description: "Open folder in your editor (default: $EDITOR or 'code')",
     },
+    { Command: colorize("thyra cd <name>"), Description: "Change directory" },
     {
       Command: colorize("thyra update <name> <folder_path>"),
       Description: "Update an existing saved path",
@@ -52,6 +52,9 @@ export function runHelp(exitCode: number) {
   )}
   ${colorize("thyra open <name> -e <editor>")}       ${color.dim(
     "# Open in <editor>",
+  )}
+  ${colorize("thyra cd <name>")}                     ${color.dim(
+    "# Change directory",
   )}
   ${colorize("thyra update <name> <folder_path>")} ${color.dim(
     "# Update an existing saved path",

--- a/tools/cli/src/commands/help.ts
+++ b/tools/cli/src/commands/help.ts
@@ -22,7 +22,10 @@ export function runHelp(exitCode: number) {
       Command: colorize("thyra open <name> [-e | --editor <editor>]"),
       Description: "Open folder in your editor (default: $EDITOR or 'code')",
     },
-    { Command: colorize("thyra cd <name>"), Description: "Change directory" },
+    {
+      Command: colorize("thyra cd <name>"),
+      Description: "Open a new Terminal window at the saved folder",
+    },
     {
       Command: colorize("thyra update <name> <folder_path>"),
       Description: "Update an existing saved path",
@@ -54,7 +57,7 @@ export function runHelp(exitCode: number) {
     "# Open in <editor>",
   )}
   ${colorize("thyra cd <name>")}                     ${color.dim(
-    "# Change directory",
+    "# Open a new Terminal window at the saved folder",
   )}
   ${colorize("thyra update <name> <folder_path>")} ${color.dim(
     "# Update an existing saved path",

--- a/tools/cli/src/commands/index.ts
+++ b/tools/cli/src/commands/index.ts
@@ -6,3 +6,4 @@ export { runHelp } from "./help";
 export { runRemove } from "./remove";
 export { runUpdate } from "./update";
 export { runImport } from "./import";
+export { runCd } from "./cd";


### PR DESCRIPTION
This pull request adds a new `cd` command to the CLI, allowing users to open a new terminal window in the directory associated with a saved project alias. It also updates the help documentation to include the new command and makes minor formatting improvements.

### New Feature: `cd` Command

* Added a new `runCd` function in `commands/cd.ts` that opens a new Terminal window at the path associated with a given alias using the `open -a Terminal` command. This provides a quick way for users to navigate to their project directories from the CLI.
* Registered the new `cd` command in the CLI entry point (`cli.ts`) and in the commands index for proper routing and export. [[1]](diffhunk://#diff-41a1e38409e2014256a03bb990da31d90b60fe4b0d96d073c678667e5fd9442dR10) [[2]](diffhunk://#diff-00dbb94511c3e8a29ff6c71b120e1bab3b6f32f039e6cf767f14b1fc0fa7131eR9) [[3]](diffhunk://#diff-41a1e38409e2014256a03bb990da31d90b60fe4b0d96d073c678667e5fd9442dR52-R54)

### Documentation Updates

* Updated the help command output to document the new `cd` command and its usage, and improved formatting for better readability. [[1]](diffhunk://#diff-f47e44fc26a5d3ee95855692ebc94e6262142a67bee8695057061d1e14ec7481R25-R33) [[2]](diffhunk://#diff-f47e44fc26a5d3ee95855692ebc94e6262142a67bee8695057061d1e14ec7481L8-R9) [[3]](diffhunk://#diff-f47e44fc26a5d3ee95855692ebc94e6262142a67bee8695057061d1e14ec7481L43-R66)

Fixes: #34 