### PR TITLE
Add editor support to project commands and update help documentation

### DIFF
--- a/tools/cli/src/commands/config.ts
+++ b/tools/cli/src/commands/config.ts
@@ -2,15 +2,16 @@ import crypto from "node:crypto";
 import path from "node:path";
 
 import { resolveFolderPath, ensureDirectoryExists } from "~/utils";
-import  { ConfigStore } from "~/core";
+import { ConfigStore } from "~/core";
 
 export function runConfig(store: ConfigStore, args: string[]): void {
   const name = args[0];
   const folderArg = args[1];
+  const editor = args[2];
 
   if (!name || !folderArg) {
     console.error("Missing arguments for 'config' command.");
-    console.log("Usage: thyra config <name> <folder_path>");
+    console.log("Usage: thyra config <name> <folder_path> [editor]");
     process.exit(1);
   }
 
@@ -25,6 +26,9 @@ export function runConfig(store: ConfigStore, args: string[]): void {
     alias: name,
     path: folderPath,
     createdAt: new Date().toISOString(),
+    editor,
   });
-  console.log(`Saved mapping: "${name}" -> ${folderPath}`);
+  console.log(
+    `Saved mapping: "${name}" -> ${folderPath}${editor ? ` (editor: ${editor})` : ""}`,
+  );
 }

--- a/tools/cli/src/commands/help.ts
+++ b/tools/cli/src/commands/help.ts
@@ -11,8 +11,8 @@ export function runHelp(exitCode: number) {
 
   const rows = [
     {
-      Command: colorize("thyra config <name> <folder_path>"),
-      Description: "Save a folder path",
+      Command: colorize("thyra config <name> <folder_path> [editor]"),
+      Description: "Save a folder path (with optional editor)",
     },
     {
       Command: colorize("thyra import <directory>"),
@@ -27,8 +27,10 @@ export function runHelp(exitCode: number) {
       Description: "Open a new Terminal window at the saved folder",
     },
     {
-      Command: colorize("thyra update <name> <folder_path>"),
-      Description: "Update an existing saved path",
+      Command: colorize(
+        "thyra update <name> [--path <folder_path>] [--editor <editor>]",
+      ),
+      Description: "Update an existing saved path or editor",
     },
     {
       Command: colorize("thyra remove <name> | --all | --force"),

--- a/tools/cli/src/commands/help.ts
+++ b/tools/cli/src/commands/help.ts
@@ -61,7 +61,7 @@ export function runHelp(exitCode: number) {
   ${colorize("thyra cd <name>")}                     ${color.dim(
     "# Open a new Terminal window at the saved folder",
   )}
-  ${colorize("thyra update <name> <folder_path>")} ${color.dim(
+  ${colorize("thyra update <name> --path <folder_path>")} ${color.dim(
     "# Update an existing saved path",
   )}
   ${colorize("thyra remove <name>")}                ${color.dim(

--- a/tools/cli/src/commands/list.ts
+++ b/tools/cli/src/commands/list.ts
@@ -16,7 +16,8 @@ export function runList(store: ConfigStore) {
     const entry = all[key];
     return {
       Command: color.cyan(entry.alias || key),
-      Description: color.dim(entry.path),
+      Description: entry.path,
+      Extra: entry.editor ? color.yellow(entry.editor) : color.dim("-"),
     };
   });
 
@@ -26,6 +27,7 @@ export function runList(store: ConfigStore) {
     header: {
       Command: "Name",
       Description: "Path",
+      Extra: "Editor",
     },
   });
 }

--- a/tools/cli/src/commands/open.ts
+++ b/tools/cli/src/commands/open.ts
@@ -62,11 +62,12 @@ function levenshteinDistance(a: string, b: string): number {
 export function runOpen(store: ConfigStore, args: string[]): void {
   const name = args[0];
 
-  let editor: string | undefined = process.env.EDITOR;
+  let flagEditor: string | undefined;
+
   if (args[1]) {
     if (args[1] === "--editor" || args[1] === "-e") {
       if (args[2]) {
-        editor = args[2];
+        flagEditor = args[2];
       } else {
         console.error("Missing <editor> argument for 'open' command.");
         console.log("Usage: thyra open <name> --editor <editor>");
@@ -120,6 +121,9 @@ export function runOpen(store: ConfigStore, args: string[]): void {
     console.error(`Invalid folder path for alias "${name}".`);
     process.exit(1);
   }
+
+  // Priority: 1. Flag, 2. Project Config, 3. Global Env, 4. Default "code"
+  const editor = flagEditor || entry.editor || process.env.EDITOR || "code";
 
   ensureDirectoryExists(entry.path);
   openInEditor(entry.path, editor);

--- a/tools/cli/src/commands/update.ts
+++ b/tools/cli/src/commands/update.ts
@@ -3,26 +3,60 @@ import { resolveFolderPath, ensureDirectoryExists } from "~/utils";
 
 export function runUpdate(store: ConfigStore, args: string[]): void {
   const name = args[0];
-  const folderArg = args[1];
 
-  if (!name || !folderArg) {
-    console.error("Missing arguments for 'update' command.");
-    console.log("Usage: thyra update <name> <folder_path>");
+  if (!name) {
+    console.error("Missing <name> argument for 'update' command.");
+    console.log(
+      "Usage: thyra update <name> [--path <folder_path>] [--editor <editor>]",
+    );
     process.exit(1);
   }
 
   if (!store.has(name)) {
     console.error(
-      `No folder found for alias "${name}". Use 'thyra list' to see saved entries.`
+      `No folder found for alias "${name}". Use 'thyra list' to see saved entries.`,
     );
     process.exit(1);
   }
 
-  const folderPath = resolveFolderPath(folderArg);
-  ensureDirectoryExists(folderPath);
-
   const entry = store.get(name)!;
-  entry.path = folderPath;
-  store.set(name, entry);
-  console.log(`Updated mapping: "${name}" -> ${folderPath}`);
+
+  let pathArg: string | undefined;
+  let editorArg: string | undefined;
+
+  // Simple flag parsing
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === "--path" && args[i + 1]) {
+      pathArg = args[i + 1];
+      i++;
+    } else if (args[i] === "--editor" && args[i + 1]) {
+      editorArg = args[i + 1];
+      i++;
+    }
+  }
+
+  let updated = false;
+
+  if (pathArg) {
+    const folderPath = resolveFolderPath(pathArg);
+    ensureDirectoryExists(folderPath);
+    entry.path = folderPath;
+    updated = true;
+  }
+
+  if (editorArg) {
+    entry.editor = editorArg;
+    updated = true;
+  }
+
+  if (updated) {
+    store.set(name, entry);
+    console.log(
+      `Updated mapping: "${name}" -> ${entry.path}${entry.editor ? ` (editor: ${entry.editor})` : ""}`,
+    );
+  } else {
+    console.log(
+      "No changes provided. Usage: thyra update <name> [--path <folder_path>] [--editor <editor>]",
+    );
+  }
 }

--- a/tools/cli/src/commands/update.ts
+++ b/tools/cli/src/commands/update.ts
@@ -24,14 +24,42 @@ export function runUpdate(store: ConfigStore, args: string[]): void {
   let pathArg: string | undefined;
   let editorArg: string | undefined;
 
-  // Simple flag parsing
   for (let i = 1; i < args.length; i++) {
-    if (args[i] === "--path" && args[i + 1]) {
-      pathArg = args[i + 1];
+    const arg = args[i];
+
+    if (arg === "--path") {
+      if (pathArg) {
+        console.error("Error: Path already specified.");
+        process.exit(1);
+      }
+      const val = args[i + 1];
+      if (!val || val.startsWith("--")) {
+        console.error("Error: Missing value for --path.");
+        process.exit(1);
+      }
+      pathArg = val;
       i++;
-    } else if (args[i] === "--editor" && args[i + 1]) {
-      editorArg = args[i + 1];
+    } else if (arg === "--editor") {
+      if (editorArg) {
+        console.error("Error: --editor already specified.");
+        process.exit(1);
+      }
+      const val = args[i + 1];
+      if (!val || val.startsWith("--")) {
+        console.error("Error: Missing value for --editor.");
+        process.exit(1);
+      }
+      editorArg = val;
       i++;
+    } else if (arg.startsWith("--")) {
+      console.error(`Error: Unknown flag '${arg}'.`);
+      process.exit(1);
+    } else {
+      if (pathArg) {
+        console.error(`Error: Unexpected argument '${arg}'.`);
+        process.exit(1);
+      }
+      pathArg = arg;
     }
   }
 
@@ -55,8 +83,9 @@ export function runUpdate(store: ConfigStore, args: string[]): void {
       `Updated mapping: "${name}" -> ${entry.path}${entry.editor ? ` (editor: ${entry.editor})` : ""}`,
     );
   } else {
-    console.log(
+    console.error(
       "No changes provided. Usage: thyra update <name> [--path <folder_path>] [--editor <editor>]",
     );
+    process.exit(1);
   }
 }

--- a/tools/cli/src/core/color-logs.ts
+++ b/tools/cli/src/core/color-logs.ts
@@ -29,12 +29,14 @@ export function colorize(cmd: string) {
 export interface CommandTableRow {
   Command: string;
   Description: string;
+  Extra?: string;
 }
 
 interface PrintCommandTableOptions {
   header?: {
     Command: string;
     Description: string;
+    Extra?: string;
   };
 }
 
@@ -42,6 +44,10 @@ export function printCommandTable(
   rows: CommandTableRow[],
   options: PrintCommandTableOptions = {},
 ) {
+  const hasExtra =
+    options.header?.Extra !== undefined ||
+    rows.some((r) => r.Extra !== undefined);
+
   const header = options.header ?? {
     Command: "Command",
     Description: "Description",
@@ -49,21 +55,35 @@ export function printCommandTable(
 
   const col1 = [header.Command, ...rows.map((r) => r.Command)];
   const col2 = [header.Description, ...rows.map((r) => r.Description)];
+  const col3 = hasExtra
+    ? [header.Extra || "", ...rows.map((r) => r.Extra || "")]
+    : [];
 
   const w1 = Math.max(...col1.map(vlen));
   const w2 = Math.max(...col2.map(vlen));
+  const w3 = hasExtra ? Math.max(...col3.map(vlen)) : 0;
 
   const sep = "  "; // spacing between columns
-  const line = (t1: string, t2: string) =>
-    padRight(t1, w1) + sep + padRight(t2, w2);
+  const line = (t1: string, t2: string, t3?: string) =>
+    padRight(t1, w1) +
+    sep +
+    padRight(t2, w2) +
+    (hasExtra ? sep + padRight(t3 || "", w3) : "");
 
   // header
-  console.log(color.bold(line(header.Command, header.Description)));
+  console.log(
+    color.bold(line(header.Command, header.Description, header.Extra)),
+  );
   // separator
-  console.log(padRight("-".repeat(w1), w1) + sep + "-".repeat(w2));
+  console.log(
+    padRight("-".repeat(w1), w1) +
+      sep +
+      "-".repeat(w2) +
+      (hasExtra ? sep + "-".repeat(w3) : ""),
+  );
 
   // rows
   for (const r of rows) {
-    console.log(line(r.Command, r.Description));
+    console.log(line(r.Command, r.Description, r.Extra));
   }
 }

--- a/tools/cli/src/types/config-store.ts
+++ b/tools/cli/src/types/config-store.ts
@@ -4,4 +4,5 @@ export interface ProjectEntry {
   alias: string;
   path: string;
   createdAt: string;
+  editor?: string;
 }


### PR DESCRIPTION
This pull request enhances the Thyra CLI tool by adding support for associating an optional editor with each saved project, and improves the usability of related commands. The changes affect how projects are configured, updated, listed, and opened, as well as how help and command tables are displayed.

**Editor support and command improvements:**

* Added an optional `editor` property to the `ProjectEntry` interface, allowing users to specify a preferred editor for each saved project. (`tools/cli/src/types/config-store.ts`)
* Updated the `config` command to accept an optional `[editor]` argument and save it with the project mapping. The usage message and confirmation output now reflect this change. (`tools/cli/src/commands/config.ts`) [[1]](diffhunk://#diff-050cac0a3001dee1e29022f2956624f3e0caa58025598f969ab8d1c485706bdcR10-R14) [[2]](diffhunk://#diff-050cac0a3001dee1e29022f2956624f3e0caa58025598f969ab8d1c485706bdcR29-R33)
* Enhanced the `update` command to allow updating either the saved path or editor (or both) using `--path` and `--editor` flags. The command now validates arguments and provides appropriate usage instructions. (`tools/cli/src/commands/update.ts`)
* Improved the `open` command to prioritize editor selection as follows: flag value, project config, environment variable, then defaulting to `"code"`. (`tools/cli/src/commands/open.ts`) [[1]](diffhunk://#diff-6614f0f0a2f780032fff367e0d7ce8712ac1ab81ce8641be3951b5e1fca4703dL65-R70) [[2]](diffhunk://#diff-6614f0f0a2f780032fff367e0d7ce8712ac1ab81ce8641be3951b5e1fca4703dR125-R127)

**User interface and help improvements:**

* Modified the `list` command and the command table printer to display the associated editor for each project, if set. (`tools/cli/src/commands/list.ts`, `tools/cli/src/core/color-logs.ts`) [[1]](diffhunk://#diff-cbfbd51b959ed50a50b637b2fd91a0feb4dc92bb9e84c649445b80c4251bfc98L19-R20) [[2]](diffhunk://#diff-cbfbd51b959ed50a50b637b2fd91a0feb4dc92bb9e84c649445b80c4251bfc98R30) [[3]](diffhunk://#diff-18bbd905d07496ebe1dd5a3256886e06d6589d5c1f4c5dafc487391a0b14ae58R32-R87)
* Updated the help output to reflect the new argument structure and descriptions for the `config` and `update` commands. (`tools/cli/src/commands/help.ts`) [[1]](diffhunk://#diff-f47e44fc26a5d3ee95855692ebc94e6262142a67bee8695057061d1e14ec7481L14-R15) [[2]](diffhunk://#diff-f47e44fc26a5d3ee95855692ebc94e6262142a67bee8695057061d1e14ec7481L30-R33)

Fixes: #33 